### PR TITLE
Removed synchronization to avoid further problems

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,6 +1,2 @@
 #!/usr/bin/bash
-
-$EASYKIVY_DIRECTORY/bin/sync.sh
 docker start -ai $CONTAINER_NAME
-mkdir bin
-docker cp $CONTAINER_NAME:/project/bin/app.apk ./bin/${CONTAINER_NAME}.apk

--- a/bin/sync.sh
+++ b/bin/sync.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/bash
-docker cp $SOURCE_DIRECTORY/. $CONTAINER_NAME:/project/.

--- a/bin/update_container_scripts.sh
+++ b/bin/update_container_scripts.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/bash
 
-docker cp $EASYKIVY_DIRECTORY/image/build.sh $CONTAINER_NAME:/project/build.sh
+docker cp $EASYKIVY_DIRECTORY/image/build.sh $CONTAINER_NAME:/usr/local/bin/build.sh

--- a/create.sh
+++ b/create.sh
@@ -112,6 +112,7 @@ then
         --volume "$CACHE_DIRECTORY/home.buildozer:/home/builder/.buildozer" \
         --volume "$CACHE_DIRECTORY/home.pip:/home/builder/.cache/pip" \
         --volume "$CACHE_DIRECTORY/home.gradle:/home/builder/.gradle" \
+	--volume "$SOURCE_DIRECTORY:/project" \
         -it \
         $IMAGE_NAME
 
@@ -139,10 +140,6 @@ export CONTAINER_NAME="${CONTAINER_NAME}"
 export SOURCE_DIRECTORY="${SOURCE_DIRECTORY}"
 export EASYKIVY_DIRECTORY="$(pwd)"
 
-easykivy_sync() {
-    \$EASYKIVY_DIRECTORY/bin/sync.sh
-}
-
 easykivy_build() {
     \$EASYKIVY_DIRECTORY/bin/build.sh
 }
@@ -157,7 +154,6 @@ easykivy_deactivate() {
     unset SOURCE_DIRECTORY
     unset EASYKIVY_DIRECTORY
 
-    unset easykivy_sync
     unset easykivy_build
     unset easykivy_update_container_scripts
     unset easykivy_deactivate

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -28,30 +28,34 @@ RUN set -x \
         git openjdk-17-jdk \
     && apt-get autoremove
 
-ADD build.sh /project/build.sh
+ADD build.sh /usr/local/bin/build.sh
 
 # Setup builder user
 RUN set -x \
     && useradd -s /usr/bin/bash -U -m builder \
     && echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers \
+    && mkdir /project \
+    && mkdir /project/.buildozer \
     && chown -R builder:builder /project/
 
 # Register volumes
 VOLUME /project
+VOLUME /project/.buildozer
 VOLUME /home/builder/.buildozer
 VOLUME /home/builder/.cache/pip
 VOLUME /home/builder/.gradle
 
-# Change user and CWD
+# Change user
 USER builder
-WORKDIR /project
-
 
 # Install buildozer and some of it's dependencies
 RUN set -x \
-    && python3 -m venv .venv \
-    && source .venv/bin/activate \
+    && python3 -m venv ~/.project_venv \
+    && source ~/.project_venv/bin/activate \
     && python3 -m pip install --upgrade pip \
     && python3 -m pip install cython buildozer python-for-android pyOpenssl
 
-ENTRYPOINT ["/project/build.sh"]
+
+# Set entrypoint and CWD
+WORKDIR /project
+ENTRYPOINT ["/usr/local/bin/build.sh"]

--- a/image/build.sh
+++ b/image/build.sh
@@ -8,7 +8,7 @@ sudo chown builder:builder -R /project
 # Activate python virtual environment
 cd /project
 rm -r bin/*
-source ./.venv/bin/activate
+source ~/.project_venv/bin/activate
 
 # Install requirements and run buildozer
 python3 -m pip install -r requirements.txt
@@ -28,11 +28,5 @@ then
     cd /project
 fi
 
-# Rename apk
-mv bin/$(ls bin/ | head -n 1) bin/app.apk
-
 # Deactivate python virtual environment
 deactivate
-
-# Write a message with what should be the next move
-echo Run "docker cp $(hostname):/project/bin/app.apk ./bin/app.apk"


### PR DESCRIPTION
There are synchronization problems in the current implementation

The container has a copy of the source code and when we try to build again with some changes the removed files from the source code are not removed.

That means if we have run R1 and run R2 as follows:

R1 file structure:
src/main.py
src/utils.py
src/whatever.py

and R2 file structure:
src/main.py
src/utils.py


(notice how src/whatever.py is not present in R2)
Then the src/whatever.py is still inside the container.

This can cause serious problems.

To fix this we are mounting the source code directory inside the container's /project folder.

This has disadvantages that any modifications to files inside the container will affect the actual source code but that doesn't seem so serious since the build process shouldn't alter any more files than what buildozer alters itself (so it's basically the same disadvantage as running without docker)

The advantage is that we ensure the code is up to date while removing lot of unecessary code and simplifying the scripts.

Detailed Changes:
* Removed easykivy_sync (sync.sh)
* Modified easykivy_build (bin/build.sh) to simply start the container
* Relocated python's virtual environment
* Relocated build.sh (image/build.sh)
* Added new volume points (/project and /project/.buildozer)